### PR TITLE
Handle named arguments in Postgres.

### DIFF
--- a/anosql/core.py
+++ b/anosql/core.py
@@ -82,16 +82,16 @@ def parse_sql_entry(db_type, e):
     elif is_postgres:
         query = re.sub(r':([a-zA-Z_-]+)', r'%(\1)s', query)
 
-    def fn(conn, *args):
+    def fn(conn, *args, **kwargs):
         results = None
         cur = conn.cursor()
 
         if sql_type == INSERT_UPDATE_DELETE:
-            cur.execute(query, args)
+            cur.execute(query, kwargs if len(kwargs) > 0 else args)
             conn.commit()
 
         if is_postgres and sql_type == AUTO_GEN:
-            cur.execute(query, args)
+            cur.execute(query, kwargs if len(kwargs) > 0 else args)
             results = cur.fetchone()[0]
             conn.commit()
 
@@ -102,7 +102,7 @@ def parse_sql_entry(db_type, e):
 
         if sql_type == SELECT:
             if '%s' in query or '?' in query or '%(':
-                cur.execute(query, args)
+                cur.execute(query, kwargs if len(kwargs) > 0 else args)
             else:
                 cur.execute(query)
             results = cur.fetchall()

--- a/anosql/core.py
+++ b/anosql/core.py
@@ -87,22 +87,22 @@ def parse_sql_entry(db_type, e):
         cur = conn.cursor()
 
         if sql_type == INSERT_UPDATE_DELETE:
-            cur.execute(query, *args)
+            cur.execute(query, args)
             conn.commit()
 
         if is_postgres and sql_type == AUTO_GEN:
-            cur.execute(query, *args)
+            cur.execute(query, args)
             results = cur.fetchone()[0]
             conn.commit()
 
         if is_sqlite and sql_type == AUTO_GEN:
-            cur.execute(query, *args)
+            cur.execute(query, args)
             results = cur.lastrowid
             conn.commit()
 
         if sql_type == SELECT:
             if '%s' in query or '?' in query or '%(':
-                cur.execute(query, *args)
+                cur.execute(query, args)
             else:
                 cur.execute(query)
             results = cur.fetchall()


### PR DESCRIPTION
This adds support for named arguments in Postgres, converting `col = :param` into  `col = %(param)s`.

This does add one import to anosql, but re is part of the standard library, so it's arguably not a new dependency. :)