### PR TITLE
Add tests for Postgresql

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,4 @@
 tox
 pytest
+testing.postgresql
+psycopg2

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -18,6 +18,26 @@ def sqlite(request):
     return sqlconnection
 
 
+@pytest.fixture
+def postgres(request):
+    import testing.postgresql
+    import psycopg2
+
+    postgresdb = testing.postgresql.Postgresql()
+    sqlconnection =  psycopg2.connect(**postgresdb.dsn())
+
+
+    def fin():
+        "teardown"
+        print("teardown")
+        sqlconnection.close()
+        postgresdb.stop()
+
+    request.addfinalizer(fin)
+
+    return sqlconnection
+
+
 def test_simple_query(sqlite):
     _test_create_insert = ("-- name: create-some-table\n"
                            "-- testing insertion\n"
@@ -72,3 +92,124 @@ def test_parametrized_insert_named(sqlite):
     q.create_some_table(sqlite)
     q.insert_some_value(sqlite, c=12, b=11, a=10)
     assert q.get_all_values(sqlite) == [(10, 11, 12)]
+
+
+def test_simple_query_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value<!\n"
+                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+    q.insert_some_value_auto(postgres)
+
+    assert q.get_all_values(postgres) == [(1, 2, 3)]
+
+
+def test_auto_insert_query_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value<!\n"
+                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+
+    assert q.insert_some_value_auto(postgres) == 1
+    assert q.insert_some_value_auto(postgres) == 2
+
+
+def test_parameterized_insert_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value!\n"
+                "INSERT INTO foo (a, b, c) VALUES (%s, %s, %s);\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+    q.insert_some_value(postgres, 1, 2, 3)
+
+    assert q.get_all_values(postgres) == [(1, 2, 3)]
+
+
+def test_auto_parameterized_insert_query_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value<!\n"
+                "INSERT INTO foo (a, b, c) VALUES (%s, %s, %s)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+
+    assert q.insert_some_value_auto(postgres, 1, 2, 3) == 1
+    assert q.get_all_values(postgres) == [(1, 2, 3)]
+
+    assert q.insert_some_value_auto(postgres, 1, 2, 3) == 2
+
+
+def test_parameterized_select_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value!\n"
+                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo WHERE a = %s;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+    q.insert_some_value(postgres)
+
+    assert q.get_all_values(postgres, 1) == [(1, 2, 3)]
+
+
+def test_parameterized_insert_named_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value!\n"
+                "INSERT INTO foo (a, b, c) VALUES (%(a)s, %(b)s, %(c)s)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+    q.insert_some_value(postgres, a=1, b=2, c=3)
+
+    assert q.get_all_values(postgres) == [(1, 2, 3)]
+
+
+def test_parameterized_select_named_pg(postgres):
+    _queries = ("-- name: create-some-table!\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int);\n\n"
+                "-- name: insert-some-value!\n"
+                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
+                "-- name: get-all-values\n"
+                "SELECT a, b, c FROM foo WHERE a = %(a)s;\n")
+
+    q = anosql.load_queries_from_string("postgres", _queries)
+
+    q.create_some_table(postgres)
+    q.insert_some_value(postgres)
+
+    assert q.get_all_values(postgres, a=1) == [(1, 2, 3)]


### PR DESCRIPTION
This PR adds tests for Postgresql, addressing issue #11. It includes analogous tests as the existing sqlite, plus a few more that are specific to insert queries.

One issue (probably for another PR) is that the Postgres tests make the suite take a long time to run—50 seconds on my machine. Testing.postgresql includes the `testing.postgresql.PostgresqlFactory` module for re-using Postgres instances, but I'll have to investigate.