### PR TITLE
Add more examples to documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ You can use parameters to do this:
   FROM greetings
   WHERE lang = %s;
 
-And they become Python named parameters:
+And they become positional parameters:
 
 .. code-block:: python
   
@@ -104,9 +104,9 @@ To make queries with many parameters more understandable and maintainable, you c
   WHERE lang = :lang
   AND len(greeting) <= :length_limit;
   
-If you were writing a Postgres query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
+If you were writing a Postgresql query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
 
-Then, call your queries like any Python function with named parameters:
+Then, call your queries like you would any Python function with named parameters:
 
 .. code-block:: python
   

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,9 @@ Installation
 Usage
 -----
 
+Basics
+******
+
 Given a ``queries.sql`` file:
 
 .. code-block:: sql
@@ -63,6 +66,54 @@ We can issue SQL queries, like so:
 
     queries.available_queries
     # => ['get_all_greetings']
+
+Parameters
+**********
+
+Often, you want to change parts of the query dynamically, particularly values in the WHERE clause.
+You can use parameters to do this:
+
+.. code-block:: sql
+
+  -- name: get-greetings-for-language-and-length
+  -- Get all the greetings in the database
+  SELECT * 
+  FROM greetings
+  WHERE lang = %s;
+
+And they become Python named parameters:
+
+.. code-block:: python
+  
+  visitor_language = "en"
+  queries.get_all_greetings(conn, visitor_language)
+
+
+
+Named Parameters
+****************
+
+To make queries with many parameters more understandable and maintainable, you can give the parameters names:
+
+.. code-block:: sql
+
+  -- name: get-greetings-for-language-and-length
+  -- Get all the greetings in the database
+  SELECT * 
+  FROM greetings
+  WHERE lang = :lang
+  AND len(greeting) <= :length_limit;
+  
+If you were writing a Postgres query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
+
+Then, call your queries like any Python function with named parameters:
+
+.. code-block:: python
+  
+  visitor_language = "en"
+
+  greetings_for_texting = queries.get_all_greetings(conn, lang=visitor_language, length_limit=140)
+
 
 Tests
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,9 @@ Installation
 Usage
 -----
 
+Basics
+******
+
 Given a ``queries.sql`` file:
 
 .. code-block:: sql
@@ -67,6 +70,54 @@ We can issue SQL queries, like so:
 
     queries.available_queries
     # => ['get_all_greetings']
+    
+  Parameters
+**********
+
+Often, you want to change parts of the query dynamically, particularly values in the WHERE clause.
+You can use parameters to do this:
+
+.. code-block:: sql
+
+  -- name: get-greetings-for-language-and-length
+  -- Get all the greetings in the database
+  SELECT * 
+  FROM greetings
+  WHERE lang = %s;
+
+And they become Python named parameters:
+
+.. code-block:: python
+  
+  visitor_language = "en"
+  queries.get_all_greetings(conn, visitor_language)
+
+
+
+Named Parameters
+****************
+
+To make queries with many parameters more understandable and maintainable, you can give the parameters names:
+
+.. code-block:: sql
+
+  -- name: get-greetings-for-language-and-length
+  -- Get all the greetings in the database
+  SELECT * 
+  FROM greetings
+  WHERE lang = :lang
+  AND len(greeting) <= :length_limit;
+  
+If you were writing a Postgres query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
+
+Then, call your queries like any Python function with named parameters:
+
+.. code-block:: python
+  
+  visitor_language = "en"
+
+  greetings_for_texting = queries.get_all_greetings(conn, lang=visitor_language, length_limit=140)
+  
 
 Caveats
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,7 +85,7 @@ You can use parameters to do this:
   FROM greetings
   WHERE lang = %s;
 
-And they become Python named parameters:
+And they become positional parameters:
 
 .. code-block:: python
   
@@ -108,9 +108,9 @@ To make queries with many parameters more understandable and maintainable, you c
   WHERE lang = :lang
   AND len(greeting) <= :length_limit;
   
-If you were writing a Postgres query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
+If you were writing a Postgresql query, you could also format the parameters as ``%s(lang)`` and ``%s(length_limit)``.
 
-Then, call your queries like any Python function with named parameters:
+Then, call your queries like you would any Python function with named parameters:
 
 .. code-block:: python
   


### PR DESCRIPTION
This adds examples about parameters and named parameters to the documentation.

Honza, I could change the example language to your mother tongue if you like to reflect the library's name. I don't recognize it though, so you'll have to tell me what it is. :)