### PR TITLE
Add optional columns descriptions

### DIFF
--- a/anosql/core.py
+++ b/anosql/core.py
@@ -60,6 +60,9 @@ def parse_sql_entry(db_type, e):
     else:
         sql_type = SELECT
 
+    use_col_description = True if name.startswith('$') else False
+    name = name.replace('$', '')
+
     # documentation are comment lines after the initial name
     is_doc = re.compile(r'\s*--\s(.*)').match
     doc = ''
@@ -89,7 +92,12 @@ def parse_sql_entry(db_type, e):
         cur.execute(query, kwargs if len(kwargs) > 0 else args)
 
         if sql_type == SELECT:
-            results = cur.fetchall()
+            cols = [col[0] for col in cur.description]
+            if use_col_description:
+                results = [dict(zip(cols, row)) for row in cur.fetchall()]
+            else:
+                results = cur.fetchall()
+
         elif sql_type == AUTO_GEN:
             if db_type == 'postgres':
                 results = cur.fetchone()[0]

--- a/anosql/core.py
+++ b/anosql/core.py
@@ -92,8 +92,8 @@ def parse_sql_entry(db_type, e):
         cur.execute(query, kwargs if len(kwargs) > 0 else args)
 
         if sql_type == SELECT:
-            cols = [col[0] for col in cur.description]
             if use_col_description:
+                cols = [col[0] for col in cur.description]
                 results = [dict(zip(cols, row)) for row in cur.fetchall()]
             else:
                 results = cur.fetchall()

--- a/anosql/core.py
+++ b/anosql/core.py
@@ -100,7 +100,8 @@ def parse_sql_entry(db_type, e):
 
         elif sql_type == AUTO_GEN:
             if db_type == 'postgres':
-                results = cur.fetchone()[0]
+                pool = cur.fetchone()
+                results = pool[0] if results else None
             elif db_type == 'sqlite':
                 results = cur.lastrowid
 

--- a/anosql/core.py
+++ b/anosql/core.py
@@ -101,7 +101,7 @@ def parse_sql_entry(db_type, e):
         elif sql_type == AUTO_GEN:
             if db_type == 'postgres':
                 pool = cur.fetchone()
-                results = pool[0] if results else None
+                results = pool[0] if pool else None
             elif db_type == 'sqlite':
                 results = cur.lastrowid
 


### PR DESCRIPTION
I think it's pretty useful feature to return dicts instead of tuples as result dataset for queries. My proposal will be next:

```
# sql file
-- name: $select-users
SELECT * FROM USERS;

# python file
queries = anosql.load_queries(..)
data = queries.select_users(conn)

# [{"id": 1, "name": "Meghan"}, {"id": 2, "name": "Harry"}]
```

What do you think?