### PR TITLE
Allow semi-colon to be omitted when last part of query is a keyword

### DIFF
--- a/anosql/patterns.py
+++ b/anosql/patterns.py
@@ -23,7 +23,7 @@ Pattern: Identifies SQL comments.
 var_pattern = re.compile(
     r'(?P<dblquote>"[^"]+")|'
     r"(?P<quote>\'[^\']+\')|"
-    r"(?P<lead>[^:]):(?P<var_name>[\w-]+)(?P<trail>[^:])"
+    r"(?P<lead>[^:]):(?P<var_name>[\w-]+)(?P<trail>[^:]?)"
 )
 """
 Pattern: Identifies variable definitions in SQL code.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -199,15 +199,8 @@ def test_without_trailing_semi_colon_pg(postgresql):
     """Make sure keywords ending queries are recognized even without
     semi-colons.
     """
-    _queries = ("-- name: create-some-table#\n"
-                "-- testing insertion\n"
-                "CREATE TABLE foo (id serial primary key, a int, b int, c int)\n\n"
-                "-- name: insert-some-value!\n"
-                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
-                "-- name: get-all-values-by-a\n"
+    _queries = ("-- name: get-by-a\n"
                 "SELECT a, b, c FROM foo WHERE a = :a\n")
     
     q = anosql.from_str(_queries, "psycopg2")
-    q.create_some_table(postgresql)
-    q.insert_some_value(postgresql)
-    assert q.get_all_values_by_a(postgresql, a=1) == [(1, 2, 3)]
+    assert q.get_by_a.sql == "SELECT a, b, c FROM foo WHERE a = %(a)s"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -193,3 +193,21 @@ def test_parameterized_select_named_pg(postgresql):
     q.insert_some_value(postgresql)
 
     assert q.get_all_values(postgresql, a=1) == [(1, 2, 3)]
+
+
+def test_without_trailing_semi_colon_pg(postgresql):
+    """Make sure keywords ending queries are recognized even without
+    semi-colons.
+    """
+    _queries = ("-- name: create-some-table#\n"
+                "-- testing insertion\n"
+                "CREATE TABLE foo (id serial primary key, a int, b int, c int)\n\n"
+                "-- name: insert-some-value!\n"
+                "INSERT INTO foo (a, b, c) VALUES (1, 2, 3)\n\n"
+                "-- name: get-all-values-by-a\n"
+                "SELECT a, b, c FROM foo WHERE a = :a\n")
+    
+    q = anosql.from_str(_queries, "psycopg2")
+    q.create_some_table(postgresql)
+    q.insert_some_value(postgresql)
+    assert q.get_all_values_by_a(postgresql, a=1) == [(1, 2, 3)]

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -195,7 +195,7 @@ def test_parameterized_select_named_pg(postgresql):
     assert q.get_all_values(postgresql, a=1) == [(1, 2, 3)]
 
 
-def test_without_trailing_semi_colon_pg(postgresql):
+def test_without_trailing_semi_colon_pg():
     """Make sure keywords ending queries are recognized even without
     semi-colons.
     """


### PR DESCRIPTION
Yesql and HugSQL [both][1] [allow][2] semi-colons be omitted in queries, e.g. in this first example from Yesql:

```sql
-- Counts the users in a given country.
SELECT count(*) AS count
FROM user
WHERE country_code = :country_code
```

In Anosql this fails when the last value in a query is a keyword because [`var_pattern` always captures at least one character for its `trail` value][3], e.g.

```sql
-- name: get-foos-by-bar
select *
  from foo
 where bar = :baz
```

```python
>>> queries.get_foos_by_bar(conn, baz='baz')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<virtualenv>/lib/python3.7/site-packages/anosql/core.py", line 176, in fn
    return driver_adapter.select(conn, query_name, sql, parameters)
  File "<virtualenv>/lib/python3.7/site-packages/anosql/adapters/psycopg2.py", line 28, in select
    cur.execute(sql, parameters)
KeyError: 'ba'
>>> queries.get_foos_by_bar.sql
'select *\n  from foo\n where bar = %(ba)sz'
```

This PR makes the `trail` part of the regex optional. All tests still pass on Python 2.7 and Python 3.5 (and Python 3.6 and Python 3.7, incidentally).

[1]: https://github.com/krisajenkins/yesql#usage
[2]: https://www.hugsql.org/#start-sql
[3]: https://github.com/honza/anosql/blob/7b765f96bcb1d15e9d35a95dffb54d304a5f9af4/anosql/patterns.py#L26