### PR TITLE
add one row expected extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ We can issue SQL queries, like so:
     queries = anosql.from_path('queries.sql', 'sqlite3')
 
     queries.get_all_greetings(conn)
-    # => [(1, 'Hi')]
+    # => [(1, 'en', 'Hi')]
 
     queries.get_all_greetings.__doc__
     # => Get all the greetings in the database
@@ -97,7 +97,30 @@ And they become positional parameters:
 
   visitor_language = "en"
   queries.get_greetings_for_language(conn, visitor_language)
+  # => [(1, 'en', 'Hi')]
 
+
+One Row Query
+*************
+
+Often, you would expect at most one row from a query, so that getting a list
+is not convenient. Appending ``?`` to the query name makes it return either one
+tuple if it returned one row, or ``None`` in other cases.
+
+.. code-block:: sql
+
+  -- name: get-a-greeting?
+  -- Get a greeting based on its id
+  SELECT *
+  FROM greetings
+  WHERE id = %s;
+
+Then a tuple is returned:
+
+.. code-block:: python
+
+  queries.get_a_greeting(conn, 1)
+  # => (1, 'en', 'Hi')
 
 
 Named Parameters

--- a/anosql/core.py
+++ b/anosql/core.py
@@ -96,6 +96,7 @@ class SQLOperationType(object):
     INSERT_UPDATE_DELETE_MANY = 2
     SCRIPT = 3
     SELECT = 4
+    SELECT_ONE_ROW = 5
 
 
 class Queries:
@@ -172,6 +173,9 @@ def _create_fns(query_name, docs, op_type, sql, driver_adapter):
             return driver_adapter.insert_update_delete_many(conn, query_name, sql, *parameters)
         elif op_type == SQLOperationType.SCRIPT:
             return driver_adapter.execute_script(conn, sql)
+        elif op_type == SQLOperationType.SELECT_ONE_ROW:
+            res = driver_adapter.select(conn, query_name, sql, parameters)
+            return res[0] if len(res) == 1 else None
         elif op_type == SQLOperationType.SELECT:
             return driver_adapter.select(conn, query_name, sql, parameters)
         else:
@@ -212,6 +216,9 @@ def load_methods(sql_text, driver_adapter):
         query_name = query_name[:-1]
     elif query_name.endswith("#"):
         op_type = SQLOperationType.SCRIPT
+        query_name = query_name[:-1]
+    elif query_name.endswith("?"):
+        op_type = SQLOperationType.SELECT_ONE_ROW
         query_name = query_name[:-1]
     else:
         op_type = SQLOperationType.SELECT

--- a/tests/blogdb/sql/users/users.sql
+++ b/tests/blogdb/sql/users/users.sql
@@ -5,3 +5,7 @@ select * from users;
 -- name: get-all-sorted
 -- Get all user records sorted by username
 select * from users order by username asc;
+
+-- name: get-one?
+-- Get one user based on its id
+select username, firstname, lastname from users where userid = %s;

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -74,6 +74,16 @@ def test_parametrized_insert_named(sqlite):
     assert q.get_all_values(sqlite) == [(10, 11, 12)]
 
 
+def test_one_row(sqlite):
+    _test_one_row = ("-- name: one-row?\n"
+                     "SELECT 1, 'hello';\n\n"
+                     "-- name: two-rows?\n"
+                     "SELECT 1 UNION SELECT 2;\n")
+    q = anosql.from_str(_test_one_row, "sqlite3")
+    assert q.one_row(sqlite) == (1, 'hello')
+    assert q.two_rows(sqlite) is None
+
+
 def test_simple_query_pg(postgresql):
     _queries = ("-- name: create-some-table#\n"
                 "-- testing insertion\n"


### PR DESCRIPTION
Returning a list of rows on a simple one row select is a pain.

The added `?` query-name marker tells that a `SELECT` returns at most one row which can be returned directly.